### PR TITLE
Add general meeting pages and update donate copy

### DIFF
--- a/src/constants/generalMeetingDocuments.ts
+++ b/src/constants/generalMeetingDocuments.ts
@@ -1,0 +1,40 @@
+export interface GeneralMeetingDocument {
+	slug: string
+	year: string
+	title: string
+	documentUrl: string
+	heldAt?: string
+	location?: string
+}
+
+const GENERAL_MEETING_LOCATION = '東洋大学赤羽台キャンパス INIAD HUB-1'
+
+export const generalMeetingDocuments: GeneralMeetingDocument[] = [
+	{
+		slug: '202511',
+		year: '2025',
+		title: '第3回総会',
+		heldAt: '2025/11/02',
+		location: GENERAL_MEETING_LOCATION,
+		documentUrl:
+			'https://drive.google.com/file/d/1wt2WAG_uiirEERkd3fVkg1EHTcEQRMHL/view?usp=sharing',
+	},
+	{
+		slug: '202411',
+		year: '2024',
+		title: '第2回総会',
+		heldAt: '2024/11/02',
+		location: GENERAL_MEETING_LOCATION,
+		documentUrl:
+			'https://drive.google.com/file/d/1jjw3UleNaGoTs2UCLwBrg5h5qn0PiDpB/view?usp=sharing',
+	},
+	{
+		slug: '202312',
+		year: '2023',
+		title: '第1回総会',
+		heldAt: '2023/12/09',
+		location: GENERAL_MEETING_LOCATION,
+		documentUrl:
+			'https://drive.google.com/file/d/1Tm1wyqcm0M6LM18tULCH928l8ZTb1TP-/view?usp=sharing',
+	},
+]

--- a/src/pages/donate/index.astro
+++ b/src/pages/donate/index.astro
@@ -5,7 +5,7 @@ import HeadingText from '../../components/common/HeadingText/HeadingText.astro'
 import Layout from '../../layouts/Layout.astro'
 ---
 
-<Layout title="寄付募集 | INIAD同窓会「INIALUM」">
+<Layout title="寄付について | INIAD同窓会「INIALUM」">
 	<main class="text-base-black">
 		<div
 			class="h-720 md:h-848 relative after:absolute after:inset-0 after:w-full after:h-full after:z-10 after:bg-linear-to-b after:from-transparent after:to-[rgba(0,0,0,0.54)]"
@@ -22,7 +22,7 @@ import Layout from '../../layouts/Layout.astro'
 				<div
 					class="flex flex-col w-full text-base-white font-bold text-[32px] sm:text-[56px]"
 				>
-					寄付募集
+					寄付について
 				</div>
 			</div>
 		</div>
@@ -32,8 +32,8 @@ import Layout from '../../layouts/Layout.astro'
 			<div class="flex flex-col break-keep gap-y-7 leading-loose">
 				<HeadingText text="Donation" />
 				<p>
-					INIAD同窓会「INIALUM」への寄付募集は、<br />
-					2026年6月ごろに開始予定です。
+					INIAD同窓会「INIALUM」への寄付受付は、<br />
+					2026年7月ごろに開始予定です。
 				</p>
 				<p>
 					現在、寄付の受付方法や詳細を準備しています。<br />

--- a/src/pages/general-meeting/[slug].astro
+++ b/src/pages/general-meeting/[slug].astro
@@ -1,0 +1,95 @@
+---
+import { ButtonLink } from '@inialum/memories-react'
+
+import { Image } from 'astro:assets'
+import iniadWallImage from '../../assets/images/other/iniad_wall.jpg'
+import HeadingText from '../../components/common/HeadingText/HeadingText.astro'
+import {
+	type GeneralMeetingDocument,
+	generalMeetingDocuments,
+} from '../../constants/generalMeetingDocuments'
+import Layout from '../../layouts/Layout.astro'
+
+interface Props {
+	document: GeneralMeetingDocument
+}
+
+export function getStaticPaths() {
+	return generalMeetingDocuments.map((document) => ({
+		params: { slug: document.slug },
+		props: { document },
+	}))
+}
+
+const { document } = Astro.props
+---
+
+<Layout title={`${document.title} | INIAD同窓会「INIALUM」`}>
+	<main class="text-base-black">
+		<div
+			class="h-720 md:h-848 relative after:absolute after:inset-0 after:w-full after:h-full after:z-10 after:bg-linear-to-b after:from-transparent after:to-[rgba(0,0,0,0.54)]"
+		>
+			<Image
+				src={iniadWallImage}
+				alt=""
+				class="object-cover w-full h-full relative"
+				quality="medium"
+			/>
+			<div
+				class="absolute left-0 right-0 bottom-0 flex flex-col items-center justify-center z-20 mx-auto max-w-470 px-10 pb-16"
+			>
+				<div
+					class="flex flex-col w-full text-base-white font-bold text-[32px] sm:text-[56px]"
+				>
+					{document.title}
+				</div>
+			</div>
+		</div>
+
+		<section
+			class="mx-auto flex max-w-470 flex-col items-start justify-center gap-y-56 px-20 py-64 text-[14px] md:max-w-580"
+		>
+			<div class="flex flex-col break-keep gap-y-7 leading-loose">
+				<HeadingText text="Documents" />
+				{
+					document.heldAt ? (
+						<p class="text-[12px] text-base-black/60">
+							開催日時: {document.heldAt}
+						</p>
+					) : null
+				}
+				{
+					document.location ? (
+						<p class="text-[12px] text-base-black/60">
+							開催場所: {document.location}
+						</p>
+					) : null
+				}
+				<p>
+					総会資料はPDF形式で公開しています。
+				</p>
+			</div>
+
+			<div class="flex w-full flex-col gap-y-24">
+				<ButtonLink
+					href={document.documentUrl}
+					target="_blank"
+					colorTheme="primary"
+					size="fullWidth"
+					className="font-bold"
+				>
+					資料を見る
+				</ButtonLink>
+				<ButtonLink
+					href="/general-meeting"
+					colorTheme="primary"
+					styleType="outlined"
+					size="fullWidth"
+					className="font-bold"
+				>
+					総会一覧へ戻る
+				</ButtonLink>
+			</div>
+		</section>
+	</main>
+</Layout>

--- a/src/pages/general-meeting/[slug].astro
+++ b/src/pages/general-meeting/[slug].astro
@@ -65,9 +65,7 @@ const { document } = Astro.props
 						</p>
 					) : null
 				}
-				<p>
-					総会資料はPDF形式で公開しています。
-				</p>
+				<p>総会資料はPDF形式で公開しています。</p>
 			</div>
 
 			<div class="flex w-full flex-col gap-y-24">

--- a/src/pages/general-meeting/index.astro
+++ b/src/pages/general-meeting/index.astro
@@ -21,9 +21,7 @@ const documentsByYear = Object.entries(
 		([year, documents]) =>
 			[
 				year,
-				documents.sort((left, right) =>
-					right.slug.localeCompare(left.slug),
-				),
+				documents.sort((left, right) => right.slug.localeCompare(left.slug)),
 			] as const,
 	)
 	.sort(([leftYear], [rightYear]) => Number(rightYear) - Number(leftYear))

--- a/src/pages/general-meeting/index.astro
+++ b/src/pages/general-meeting/index.astro
@@ -1,0 +1,113 @@
+---
+import { Image } from 'astro:assets'
+import iniadWallImage from '../../assets/images/other/iniad_wall.jpg'
+import HeadingText from '../../components/common/HeadingText/HeadingText.astro'
+import { generalMeetingDocuments } from '../../constants/generalMeetingDocuments'
+import Layout from '../../layouts/Layout.astro'
+
+const documentsByYear = Object.entries(
+	generalMeetingDocuments.reduce<
+		Record<string, typeof generalMeetingDocuments>
+	>((groups, document) => {
+		if (!groups[document.year]) {
+			groups[document.year] = []
+		}
+
+		groups[document.year].push(document)
+		return groups
+	}, {}),
+)
+	.map(
+		([year, documents]) =>
+			[
+				year,
+				documents.sort((left, right) =>
+					right.slug.localeCompare(left.slug),
+				),
+			] as const,
+	)
+	.sort(([leftYear], [rightYear]) => Number(rightYear) - Number(leftYear))
+---
+
+<Layout title="総会 | INIAD同窓会「INIALUM」">
+	<main class="text-base-black">
+		<div
+			class="h-720 md:h-848 relative after:absolute after:inset-0 after:w-full after:h-full after:z-10 after:bg-linear-to-b after:from-transparent after:to-[rgba(0,0,0,0.54)]"
+		>
+			<Image
+				src={iniadWallImage}
+				alt=""
+				class="object-cover w-full h-full relative"
+				quality="medium"
+			/>
+			<div
+				class="absolute left-0 right-0 bottom-0 flex flex-col items-center justify-center z-20 mx-auto max-w-470 px-10 pb-16"
+			>
+				<div
+					class="flex flex-col w-full text-base-white font-bold text-[32px] sm:text-[56px]"
+				>
+					総会
+				</div>
+			</div>
+		</div>
+
+		<section
+			class="mx-auto flex max-w-470 flex-col items-start justify-center gap-y-56 px-20 py-64 text-[14px] md:max-w-580"
+		>
+			<div class="flex flex-col break-keep gap-y-7 leading-loose">
+				<HeadingText text="General Meeting" />
+				<p>
+					一年に一度開催される総会に関する資料を、<br />
+					年度ごとに掲載します。
+				</p>
+			</div>
+
+			{
+				documentsByYear.length > 0 ? (
+					<div class="flex w-full flex-col gap-y-32">
+						{documentsByYear.map(([year, documents]) => (
+							<section
+								class="flex flex-col gap-y-14"
+								aria-labelledby={`general-meeting-${year}`}
+							>
+								<div class="border-b border-primary/20 pb-8">
+									<div
+										id={`general-meeting-${year}`}
+										class="text-[24px] font-bold leading-none"
+									>
+										{year}
+									</div>
+								</div>
+								<div class="flex flex-col">
+									{documents.map((document) => (
+										<a
+											href={`/general-meeting/${document.slug}`}
+											class="flex items-center justify-between gap-16 border-b border-base-black/10 py-16 transition-colors hover:text-primary"
+										>
+											<div class="flex flex-col gap-y-4">
+												<p class="text-[16px] font-bold">{document.title}</p>
+												{document.heldAt ? (
+													<p class="text-[12px] text-base-black/60">
+														開催日時: {document.heldAt}
+													</p>
+												) : null}
+											</div>
+											<div class="shrink-0 text-[12px] font-bold text-primary">
+												詳細を見る
+											</div>
+										</a>
+									))}
+								</div>
+							</section>
+						))}
+					</div>
+				) : (
+					<div class="flex flex-col break-keep gap-y-7 leading-loose">
+						<p>現在、公開中の総会資料はありません。</p>
+						<p>資料の公開準備が整い次第、このページに年度ごとに掲載します。</p>
+					</div>
+				)
+			}
+		</section>
+	</main>
+</Layout>


### PR DESCRIPTION
## Summary
- Add a general meeting index page plus per-meeting detail pages backed by Drive links
- Capture meeting metadata like title, held date, and location for each entry
- Update the donate page wording to match the current schedule and page label

## Testing
- `pnpm build`